### PR TITLE
refactor: unify context-length statistics into one estimator

### DIFF
--- a/angelus/context_stats.py
+++ b/angelus/context_stats.py
@@ -1,0 +1,83 @@
+"""Unified context-length estimation for history stats and previews.
+
+One pure entry point estimates the wire length of a message/tool payload.
+The character basis is the JSON serialization used by
+``llmfetcher.context_handlers.linear``'s compaction estimator
+(``len(json.dumps(x, ensure_ascii=False, default=str))``), and the token
+proxy is the same ceiling division ``(characters + 3) // 4`` used by the
+request-preview statistics. Real token usage stays on the usage ledger and
+is deliberately not part of this estimator.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ContextLengthStats:
+    """Character and token estimate for one message/tool-schema payload.
+
+    Attributes:
+        messages: Number of serializable message dicts in the input list.
+        characters: Total serialized character length of the messages.
+        tool_schemas: Number of tool-schema dicts supplied (0 when absent).
+        tool_schema_characters: Total serialized character length of the
+            tool schemas (0 when no schemas were supplied).
+        estimated_tokens: Ceiling-divided token proxy for ``characters``
+            only, matching ``(characters + 3) // 4``.
+    """
+
+    messages: int
+    characters: int
+    tool_schemas: int
+    tool_schema_characters: int
+    estimated_tokens: int
+
+
+def estimate_context_length(
+    messages: list[dict[str, Any]],
+    tool_schemas: list[dict[str, Any]] | None = None,
+) -> ContextLengthStats:
+    """Estimate the serialized wire length of one provider message payload.
+
+    Args:
+        messages: Provider message dicts, usually in send order. Non-dict
+            entries are skipped defensively so malformed checkpoints cannot
+            break the estimator.
+        tool_schemas: Optional tool definitions that travel with the request.
+            When ``None`` the schema counts stay at zero.
+
+    Returns:
+        A frozen :class:`ContextLengthStats` with serialized character counts
+        and the derived token estimate. ``estimated_tokens`` covers only the
+        message characters; tool schemas are reported separately so callers
+        decide whether to include them.
+    """
+    valid_messages = [item for item in messages if isinstance(item, dict)]
+    characters = sum(
+        len(json.dumps(item, ensure_ascii=False, default=str))
+        for item in valid_messages
+    )
+    if tool_schemas is None:
+        return ContextLengthStats(
+            messages=len(valid_messages),
+            characters=characters,
+            tool_schemas=0,
+            tool_schema_characters=0,
+            estimated_tokens=(characters + 3) // 4,
+        )
+    valid_tools = [item for item in tool_schemas if isinstance(item, dict)]
+    tool_characters = sum(
+        len(json.dumps(item, ensure_ascii=False, default=str))
+        for item in valid_tools
+    )
+    return ContextLengthStats(
+        messages=len(valid_messages),
+        characters=characters,
+        tool_schemas=len(valid_tools),
+        tool_schema_characters=tool_characters,
+        estimated_tokens=(characters + 3) // 4,
+    )

--- a/angelus/history.py
+++ b/angelus/history.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from .markdown import render_markdown
+from .context_stats import estimate_context_length
 from . import storage
 from .storage import (
     _conversation_path,
@@ -635,9 +636,14 @@ def _agent_context_preview(session_id: str, agent_name: str) -> AgentContextPrev
             timeline=request_timeline,
         ) for index, message in enumerate(messages, start=1)]
         tool_schemas = [item for item in request.get("tools", []) if isinstance(item, dict)]
-        message_characters = sum(len(json.dumps(item, ensure_ascii=False, default=str)) for item in messages)
-        tool_characters = sum(len(json.dumps(item, ensure_ascii=False, default=str)) for item in tool_schemas)
-        stats = RemoteRequestStats(len(messages), message_characters, len(tool_schemas), tool_characters, (message_characters + tool_characters + 3) // 4)
+        estimate = estimate_context_length(messages, tool_schemas)
+        stats = RemoteRequestStats(
+            estimate.messages,
+            estimate.characters,
+            estimate.tool_schemas,
+            estimate.tool_schema_characters,
+            estimate.estimated_tokens,
+        )
     return AgentContextPreview(
         messages=messages,
         metadata=metadata,
@@ -829,9 +835,11 @@ def _agent_context_stats(session_id: str, agent_name: str) -> dict[str, Any]:
 
     Returns:
         Dict with ``messages``, ``characters``, ``abstract_characters``,
-        ``compacted``, ``threshold``, ``round`` and ``ratio`` keys. Missing
-        or malformed context files yield all-zero defaults so the UI can
-        render an empty state instead of failing.
+        ``compacted``, ``threshold``, ``round`` and ``ratio`` keys, plus the
+        unified ``estimated_tokens`` proxy and ``tool_schema_characters``
+        (always zero here because a checkpoint has no standalone tools
+        snapshot). Missing or malformed context files yield all-zero
+        defaults so the UI can render an empty state instead of failing.
     """
     stats = {
         "messages": 0,
@@ -841,6 +849,8 @@ def _agent_context_stats(session_id: str, agent_name: str) -> dict[str, Any]:
         "threshold": 0,
         "round": 0,
         "ratio": 0.0,
+        "estimated_tokens": 0,
+        "tool_schema_characters": 0,
     }
     try:
         safe_session = _safe_id(session_id, "session")
@@ -855,12 +865,11 @@ def _agent_context_stats(session_id: str, agent_name: str) -> dict[str, Any]:
 
     messages = raw.get("messages", [])
     if isinstance(messages, list):
-        stats["messages"] = len(messages)
-        stats["characters"] = sum(
-            len(json.dumps(msg, ensure_ascii=False, default=str))
-            for msg in messages
-            if isinstance(msg, dict)
-        )
+        estimate = estimate_context_length(messages)
+        stats["messages"] = estimate.messages
+        stats["characters"] = estimate.characters
+        stats["estimated_tokens"] = estimate.estimated_tokens
+        stats["tool_schema_characters"] = estimate.tool_schema_characters
 
     abstract = raw.get("abstract")
     if isinstance(abstract, dict):

--- a/docs/context-stats-change-notes.md
+++ b/docs/context-stats-change-notes.md
@@ -1,0 +1,59 @@
+# 上下文长度统计统一口径 — 变更说明
+
+实现 `docs/context-stats-unification-spec.md`，为 F1（checkpoint 字符统计）与 F2
+（远程请求预览统计）建立唯一估算入口。F3/F4（`llmfetcher` 子模块）源码未改动。
+
+## 新增 `angelus/context_stats.py`
+
+- `ContextLengthStats`：frozen dataclass，字段
+  `messages / characters / tool_schemas / tool_schema_characters / estimated_tokens`。
+- `estimate_context_length(messages, tool_schemas=None)`：纯函数。
+  - 字符基准：`len(json.dumps(x, ensure_ascii=False, default=str))`（与 F3
+    `llmfetcher/context_handlers/linear.py::_estimate_context_size` 同一口径）。
+  - token 估算：`estimated_tokens = (characters + 3) // 4`，仅以消息字符为基数；
+    tool schema 字符单独统计，不混入 token 估算。
+  - 防御：非 dict 条目被跳过，畸形 checkpoint 不会导致估算崩溃。
+
+## `angelus/history.py` 改造
+
+1. `_agent_context_stats`（F1）
+   - 消息字符统计委托给 `estimate_context_length(messages)`。
+   - 返回键保持向后兼容：`messages / characters / abstract_characters /
+     compacted / threshold / round / ratio`。
+   - 新增键 `estimated_tokens`（= `(characters+3)//4`）与 `tool_schema_characters`
+     （恒为 0，checkpoint 不含独立 tools 快照）。
+2. `_agent_context_preview`（F2）
+   - `RemoteRequestStats` 改为用 `estimate_context_length(messages, tool_schemas)`
+     生成；`RemoteRequestStats` 字段（messages/characters/tool_schemas/
+     tool_schema_characters/estimated_tokens）保持不变。
+   - 语义差异：`estimated_tokens` 现基于消息字符（旧实现把 tool schema 字符也计入
+     token 估算），与统一口径一致，前端无需改字段名。
+
+## 调用方确认
+
+- `angelus/api/sessions.py`：仅把 `_agent_context_stats` 结果作为 `context` 字段
+  透传给前端（只读），不依赖字段值以外的形状变化。
+- `angelus/api/compact.py`：仅读取 `before.get('messages')` 与
+  `after.get('abstract_characters')`，新增键不影响。
+
+## 测试
+
+- 新增 `tests/test_context_stats.py`（7 个用例）：
+  - 空列表 / 普通消息 / 带 tools 的 `estimate_context_length` 统计。
+  - `_agent_context_stats` 含 `estimated_tokens` 且等于 `(characters+3)//4`。
+  - preview `RemoteRequestStats` 字段与统一估算器一致。
+- `python -m pytest tests`：332 passed（基线 325 + 新增 7）。
+
+## 前端 `frontend/static/app.js`
+
+- `renderContextPrompt`（F2，约 L254）不改：继续消费
+  `stats.messages / stats.characters / stats.tool_schemas /
+  stats.tool_schema_characters / stats.estimated_tokens`。
+- `agentContextStats`（F1，约 L278）保持既有字段与文案不变：
+  `characters / abstract_characters / threshold / compacted / ratio`；
+  按 spec 的可选增强新增 `estimated_tokens`：
+  - 新增 `const estimatedTokens = Number(ctx.estimated_tokens || 0);`
+  - `estimated_tokens > 0` 时在可见文本追加 ` · 估算 N tokens`，并在 tooltip
+    中追加 ` · 估算 N tokens`；为 0/缺失时不渲染任何新片段，旧 UI 完全不变。
+- 未改动 `tests/test_workbench_assets.py` 断言的任何字符串。
+- 验证：`python -m pytest tests` 337 passed。

--- a/docs/context-stats-unification-spec.md
+++ b/docs/context-stats-unification-spec.md
@@ -1,0 +1,35 @@
+# 上下文长度统计统一口径 Spec
+
+仓库：`/home/luna/Documents/codes/python/angelus_lunae/angelus-context-stats`（worktree，分支 `refactor/unify-context-stats`）
+约束：**不改 llmfetcher 子模块源码**（F3/F4 内部实现保持原样，仅在 angelus 侧统一估算入口）。
+
+## 背景：现存的多套统计
+
+- **F1** `angelus/history.py::_agent_context_stats()` — 读持久化 `contexts/<agent>.json` 的字符统计（messages/characters/abstract_characters/compacted/threshold/round/ratio）。
+- **F2** `angelus/history.py::_agent_context_preview()` 内 `RemoteRequestStats` — 对事件日志中最近一次远程请求快照的字符统计（messages/characters/tool_schemas/tool_schema_characters/estimated_tokens）。
+- **F3** `llmfetcher/context_handlers/linear.py::_estimate_context_size()` — 运行时估算实际发送请求体字符长度，驱动压缩（不改）。
+- **F4** `angelus/history.py::_session_usage_summary()` + `llmfetcher/usage_ledger.py` — 真实 token 用量账本（不改）。
+
+## 统一口径决策
+
+1. **唯一估算基准**：JSON 序列化后的**字符长度**（`len(json.dumps(x, ensure_ascii=False, default=str))`），与 F3 内部基准一致。
+2. **唯一 token 估算系数**：`estimated_tokens = characters // 4`（等价于现有 F2 的 `(chars+3)//4`，即 ceil 除法；两者在整数语义上一致，采用 `(characters + 3) // 4` 保留向上取整）。
+3. **唯一统计入口**：新增模块 `angelus/context_stats.py`，导出纯函数，供 F1/F2 共用：
+   - `estimate_context_length(messages: list[dict], tool_schemas: list[dict] | None = None) -> ContextLengthStats`
+   - `ContextLengthStats`（frozen dataclass）：`messages:int, characters:int, tool_schemas:int, tool_schema_characters:int, estimated_tokens:int`
+4. **F1 改造**：`_agent_context_stats` 内部把消息字符统计委托给 `estimate_context_length`；返回字段**保持向后兼容**（messages/characters/abstract_characters/compacted/threshold/round/ratio），额外新增 `estimated_tokens`（基于 characters 统一导出）与 `tool_schema_characters`（默认为 0，因为 checkpoint 不含独立 tools 快照）。
+5. **F2 改造**：`_agent_context_preview` 用 `estimate_context_length(messages, tool_schemas)` 构造 `RemoteRequestStats`；`RemoteRequestStats` 字段保持不变。
+6. **F3/F4**：不改源码。文档注明 F3 已用同一字符基准；F4 为真实 token，不参与估算，前端需明确标注"真实用量"。
+
+## 前端字段映射（frontend/static/app.js）
+
+- F2 `renderContextPrompt`（第 254 行）继续用 `stats.messages/stats.characters/stats.tool_schemas/stats.tool_schema_characters/stats.estimated_tokens` —— 不变。
+- F1 展示处（第 281-285 行 `context` 对象）继续用 `characters/abstract_characters/threshold/compacted/ratio` —— 不变；新增 `estimated_tokens` 可选展示（不强制，前端若已显示可加）。
+
+## 测试要求
+
+- 新增 `tests/test_context_stats.py`：
+  - `estimate_context_length` 对空列表、普通消息、带 tools 的输入返回正确统计。
+  - `_agent_context_stats` 返回键含新字段 `estimated_tokens` 且值等于 `(characters+3)//4`。
+  - `RemoteRequestStats`/preview 仍返回统一字段。
+- 不改 llmfetcher 子模块测试；`python -m pytest tests` 全绿（基线 325 passed）。

--- a/frontend/static/app.js
+++ b/frontend/static/app.js
@@ -283,6 +283,7 @@ function agentContextStats(agent) {
   const threshold = Number(ctx.threshold || 0);
   const compacted = Boolean(ctx.compacted);
   const ratio = Number(ctx.ratio || 0);
+  const estimatedTokens = Number(ctx.estimated_tokens || 0);
 
   if (!messages && !chars && !abstractChars) {
     return `<small class="agent-context">上下文：—</small>`;
@@ -292,7 +293,8 @@ function agentContextStats(agent) {
   const ratioLabel = threshold > 0 ? ` · ${Math.round(ratio * 100)}%` : "";
   const compactLabel = compacted ? ` · 已压缩` : "";
   const thresholdLabel = threshold > 0 ? ` / 阈值 ${threshold.toLocaleString()}` : "";
-  return `<small class="agent-context" title="消息 ${messages} 条 · 字符 ${chars + abstractChars} · 压缩阈值 ${threshold}">上下文：${messages} 条 · ${charsLabel} 字符${thresholdLabel}${ratioLabel}${compactLabel}</small>`;
+  const tokensLabel = estimatedTokens > 0 ? ` · 估算 ${estimatedTokens.toLocaleString()} tokens` : "";
+  return `<small class="agent-context" title="消息 ${messages} 条 · 字符 ${chars + abstractChars} · 压缩阈值 ${threshold}${estimatedTokens > 0 ? ` · 估算 ${estimatedTokens.toLocaleString()} tokens` : ""}">上下文：${messages} 条 · ${charsLabel} 字符${thresholdLabel}${ratioLabel}${compactLabel}${tokensLabel}</small>`;
 }
 
 /** Render the delegation tree; activating one Agent opens its context graph. */

--- a/tests/test_context_stats.py
+++ b/tests/test_context_stats.py
@@ -1,0 +1,319 @@
+"""Spec coverage for unified context-length statistics.
+
+Contract source: ``docs/context-stats-unification-spec.md``.
+
+- ``angelus.context_stats.estimate_context_length`` is the single estimation
+  entry point (characters = JSON serialized length, ``estimated_tokens =
+  (characters + 3) // 4``).
+- ``angelus.history._agent_context_stats`` exposes the new ``estimated_tokens``
+  and ``tool_schema_characters`` keys while keeping the legacy
+  messages/characters/abstract_characters/compacted/threshold/round/ratio keys.
+- ``angelus.history._agent_context_preview`` builds a complete
+  ``RemoteRequestStats`` from ``estimate_context_length``.
+
+The ``context_stats`` module is developed by a parallel worker; the tests skip
+with a clear reason if it is not importable yet.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from angelus import storage
+from angelus.history import (
+    RemoteRequestStats,
+    _agent_context_preview,
+    _agent_context_stats,
+)
+
+try:
+    from angelus.context_stats import ContextLengthStats, estimate_context_length
+    HAS_CONTEXT_STATS = True
+except ImportError:  # pragma: no cover - parallel-worker backend not landed yet
+    estimate_context_length = None
+    HAS_CONTEXT_STATS = False
+
+
+def _json_length(value: object) -> int:
+    """Reference serializer matching the spec's unique character basis."""
+    return len(json.dumps(value, ensure_ascii=False, default=str))
+
+
+class ContextLengthStatsTests(unittest.TestCase):
+    """``estimate_context_length`` produces spec-compliant size statistics."""
+
+    def test_empty_list_is_all_zeros(self) -> None:
+        if not HAS_CONTEXT_STATS:
+            self.skipTest("angelus.context_stats not implemented yet")
+        stats = estimate_context_length([])
+        self.assertEqual(stats.messages, 0)
+        self.assertEqual(stats.characters, 0)
+        self.assertEqual(stats.tool_schemas, 0)
+        self.assertEqual(stats.tool_schema_characters, 0)
+        self.assertEqual(stats.estimated_tokens, 0)
+
+    def test_empty_list_with_empty_tools_is_all_zeros(self) -> None:
+        if not HAS_CONTEXT_STATS:
+            self.skipTest("angelus.context_stats not implemented yet")
+        stats = estimate_context_length([], [])
+        self.assertEqual(stats.messages, 0)
+        self.assertEqual(stats.characters, 0)
+        self.assertEqual(stats.tool_schemas, 0)
+        self.assertEqual(stats.tool_schema_characters, 0)
+        self.assertEqual(stats.estimated_tokens, 0)
+
+    def test_plain_messages_are_measured_and_tokens_derived(self) -> None:
+        if not HAS_CONTEXT_STATS:
+            self.skipTest("angelus.context_stats not implemented yet")
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        expected_characters = sum(_json_length(item) for item in messages)
+
+        stats = estimate_context_length(messages)
+
+        self.assertEqual(stats.messages, 2)
+        self.assertEqual(stats.characters, expected_characters)
+        self.assertEqual(stats.estimated_tokens, (expected_characters + 3) // 4)
+        self.assertEqual(stats.tool_schemas, 0)
+        self.assertEqual(stats.tool_schema_characters, 0)
+
+    def test_tool_schemas_are_counted_separately(self) -> None:
+        if not HAS_CONTEXT_STATS:
+            self.skipTest("angelus.context_stats not implemented yet")
+        messages = [{"role": "user", "content": "call a tool"}]
+        tool_schemas = [
+            {"type": "function", "function": {"name": "search", "parameters": {"q": "x"}}},
+            {"type": "function", "function": {"name": "summarize"}},
+        ]
+        expected_characters = sum(_json_length(item) for item in messages)
+        expected_tool_characters = sum(_json_length(item) for item in tool_schemas)
+
+        stats = estimate_context_length(messages, tool_schemas)
+
+        self.assertEqual(stats.messages, 1)
+        self.assertEqual(stats.characters, expected_characters)
+        self.assertEqual(stats.tool_schemas, 2)
+        self.assertEqual(stats.tool_schema_characters, expected_tool_characters)
+        self.assertEqual(stats.estimated_tokens, (expected_characters + 3) // 4)
+
+    def test_non_dict_entries_are_skipped_defensively(self) -> None:
+        if not HAS_CONTEXT_STATS:
+            self.skipTest("angelus.context_stats not implemented yet")
+        messages = [
+            {"role": "user", "content": "kept"},
+            "not-a-dict",
+            None,
+            42,
+        ]
+        tool_schemas = [
+            {"type": "function", "function": {"name": "search"}},
+            "junk-tool",
+        ]
+        expected_characters = sum(_json_length(item) for item in messages if isinstance(item, dict))
+
+        stats = estimate_context_length(messages, tool_schemas)
+
+        self.assertEqual(stats.messages, 1)
+        self.assertEqual(stats.characters, expected_characters)
+        self.assertEqual(stats.tool_schemas, 1)
+        self.assertEqual(stats.tool_schema_characters, _json_length(tool_schemas[0]))
+        self.assertEqual(stats.estimated_tokens, (expected_characters + 3) // 4)
+
+    def test_result_is_a_frozen_dataclass_with_full_fields(self) -> None:
+        if not HAS_CONTEXT_STATS:
+            self.skipTest("angelus.context_stats not implemented yet")
+        stats = estimate_context_length([{"role": "user", "content": "x"}])
+        self.assertTrue(dataclasses.is_dataclass(stats))
+        self.assertIsInstance(stats, ContextLengthStats)
+        self.assertEqual(
+            [field.name for field in dataclasses.fields(stats)],
+            ["messages", "characters", "tool_schemas", "tool_schema_characters", "estimated_tokens"],
+        )
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            stats.messages = 99  # type: ignore[misc]
+
+
+class AgentContextStatsTests(unittest.TestCase):
+    """``_agent_context_stats`` keeps legacy keys and adds the spec fields."""
+
+    SPEC_KEYS = (
+        "messages",
+        "characters",
+        "abstract_characters",
+        "compacted",
+        "threshold",
+        "round",
+        "ratio",
+        "estimated_tokens",
+        "tool_schema_characters",
+    )
+
+    def _assert_all_spec_keys_present(self, stats: dict) -> None:
+        self.assertEqual(set(self.SPEC_KEYS), set(stats))
+
+    def test_missing_context_yields_all_zero_spec_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            original_root = storage.WORKSPACE_ROOT
+            storage.WORKSPACE_ROOT = Path(directory)
+            try:
+                stats = _agent_context_stats("work", "coordinator")
+                self._assert_all_spec_keys_present(stats)
+                self.assertEqual(stats["messages"], 0)
+                self.assertEqual(stats["characters"], 0)
+                self.assertEqual(stats["abstract_characters"], 0)
+                self.assertEqual(stats["compacted"], False)
+                self.assertEqual(stats["threshold"], 0)
+                self.assertEqual(stats["round"], 0)
+                self.assertEqual(stats["ratio"], 0.0)
+                self.assertEqual(stats["estimated_tokens"], 0)
+                self.assertEqual(stats["tool_schema_characters"], 0)
+            finally:
+                storage.WORKSPACE_ROOT = original_root
+
+    def test_context_stats_include_estimated_tokens_and_keep_legacy_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            original_root = storage.WORKSPACE_ROOT
+            storage.WORKSPACE_ROOT = Path(directory)
+            try:
+                messages = [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi"},
+                    {"role": "user", "content": "third"},
+                ]
+                expected_characters = sum(_json_length(item) for item in messages)
+                storage._context_path("work", "work", "coordinator").write_text(
+                    json.dumps({"messages": messages}), encoding="utf-8"
+                )
+
+                stats = _agent_context_stats("work", "coordinator")
+
+                self._assert_all_spec_keys_present(stats)
+                self.assertEqual(stats["messages"], 3)
+                self.assertEqual(stats["characters"], expected_characters)
+                self.assertEqual(stats["estimated_tokens"], (expected_characters + 3) // 4)
+                self.assertEqual(stats["tool_schema_characters"], 0)
+                # Checkpoint-only stats stay at their legacy defaults.
+                self.assertEqual(stats["abstract_characters"], 0)
+                self.assertEqual(stats["compacted"], False)
+                self.assertEqual(stats["threshold"], 0)
+                self.assertEqual(stats["round"], 0)
+                self.assertEqual(stats["ratio"], 0.0)
+            finally:
+                storage.WORKSPACE_ROOT = original_root
+
+    def test_context_stats_preserve_compaction_and_ratio_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            original_root = storage.WORKSPACE_ROOT
+            storage.WORKSPACE_ROOT = Path(directory)
+            try:
+                messages = [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "world"},
+                ]
+                abstract = {"summary": "compacted conversation", "source_timeline": [1, 2]}
+                threshold = 200
+                expected_characters = sum(_json_length(item) for item in messages)
+                expected_abstract = _json_length(abstract)
+                storage._context_path("work", "work", "coordinator").write_text(
+                    json.dumps({
+                        "messages": messages,
+                        "abstract": abstract,
+                        "compress_threshold": threshold,
+                        "round": 4,
+                    }),
+                    encoding="utf-8",
+                )
+
+                stats = _agent_context_stats("work", "coordinator")
+
+                self._assert_all_spec_keys_present(stats)
+                self.assertEqual(stats["messages"], 2)
+                self.assertEqual(stats["characters"], expected_characters)
+                self.assertEqual(stats["estimated_tokens"], (expected_characters + 3) // 4)
+                self.assertEqual(stats["tool_schema_characters"], 0)
+                self.assertTrue(stats["compacted"])
+                self.assertEqual(stats["abstract_characters"], expected_abstract)
+                self.assertEqual(stats["threshold"], threshold)
+                self.assertEqual(stats["round"], 4)
+                expected_ratio = round(min(1.0, (expected_characters + expected_abstract) / threshold), 4)
+                self.assertEqual(stats["ratio"], expected_ratio)
+            finally:
+                storage.WORKSPACE_ROOT = original_root
+
+
+class AgentContextPreviewStatsTests(unittest.TestCase):
+    """``RemoteRequestStats`` from ``_agent_context_preview`` stays complete."""
+
+    STAT_FIELDS = ("messages", "characters", "tool_schemas", "tool_schema_characters", "estimated_tokens")
+
+    def test_remote_request_stats_dataclass_fields_are_complete(self) -> None:
+        self.assertEqual([field.name for field in dataclasses.fields(RemoteRequestStats)], list(self.STAT_FIELDS))
+        self.assertTrue(all(field.type in ("int", int) for field in dataclasses.fields(RemoteRequestStats)))
+        self.assertTrue(dataclasses.is_dataclass(RemoteRequestStats))
+
+    def test_preview_stats_match_estimate_context_length(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            original_root = storage.WORKSPACE_ROOT
+            storage.WORKSPACE_ROOT = Path(directory)
+            try:
+                storage._context_path("work", "work", "worker").write_text(
+                    json.dumps({"messages": []}), encoding="utf-8"
+                )
+                request = {
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "exact request"}],
+                    "tools": [
+                        {"type": "function", "function": {"name": "search", "parameters": {"q": "x"}}},
+                    ],
+                }
+                storage._append_session_event("work", "work", {
+                    "event": "lifecycle",
+                    "type": "agent:remote_request",
+                    "agent": "worker",
+                    "data": {"request": request},
+                })
+
+                preview = _agent_context_preview("work", "worker")
+
+                self.assertIsNotNone(preview.stats)
+                message_chars = sum(_json_length(item) for item in request["messages"])
+                tool_chars = sum(_json_length(item) for item in request["tools"])
+                self.assertEqual(preview.stats.messages, len(request["messages"]))
+                self.assertEqual(preview.stats.characters, message_chars)
+                self.assertEqual(preview.stats.tool_schemas, len(request["tools"]))
+                self.assertEqual(preview.stats.tool_schema_characters, tool_chars)
+                self.assertEqual(preview.stats.estimated_tokens, (message_chars + 3) // 4)
+
+                serialized = preview.to_dict()
+                self.assertEqual(set(serialized["stats"]), set(self.STAT_FIELDS))
+            finally:
+                storage.WORKSPACE_ROOT = original_root
+
+    def test_preview_without_remote_request_has_no_stats(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            original_root = storage.WORKSPACE_ROOT
+            storage.WORKSPACE_ROOT = Path(directory)
+            try:
+                storage._context_path("work", "work", "worker").write_text(
+                    json.dumps({"messages": [{"role": "user", "content": "hello"}]}), encoding="utf-8"
+                )
+
+                preview = _agent_context_preview("work", "worker")
+
+                self.assertIsNone(preview.stats)
+                self.assertIsNone(preview.request)
+                serialized = preview.to_dict()
+                self.assertIsNone(serialized["stats"])
+                self.assertEqual(set(serialized), {"messages", "metadata", "request", "total", "stats"})
+            finally:
+                storage.WORKSPACE_ROOT = original_root
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Unify all context-length statistics into a single estimator module so every code path reports the same numbers.

## What changed

- **New `angelus/context_stats.py`** — single entry point `estimate_context_length` plus a frozen `ContextLengthStats` dataclass. Character base is `len(json.dumps(x, ensure_ascii=False, default=str))`; `estimated_tokens = (characters + 3) // 4`.
- **`angelus/history.py`** — `_agent_context_stats` delegates to the unified estimator while keeping the old keys (`messages` / `characters` / `abstract_characters` / `compacted` / `threshold` / `round` / `ratio`) for backward compatibility, and adds `estimated_tokens` + `tool_schema_characters`. `_agent_context_preview` now uses `estimate_context_length` to build `RemoteRequestStats` with unchanged fields.
- **`frontend/static/app.js`** — `agentContextStats` shows “· 估算 N tokens” when `estimated_tokens > 0` (optional enhancement; `renderContextPrompt` unchanged).
- **Tests** — new `tests/test_context_stats.py` with 12 cases.

## Verification

- `python -m pytest tests` → **337 passed** (325 baseline + 12 new).
- `node --check frontend/static/app.js` → OK.
- `llmfetcher` submodule untouched (gitlink still `f1d0aa5`, not part of this branch).

## Docs

- `docs/context-stats-unification-spec.md`
- `docs/context-stats-change-notes.md`